### PR TITLE
Added new configurations to suppress the doorbell ringing for the Opener on ring-to-open and in continuous mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Start homebridge with the plugin installed, however, do not provide any devices 
                     "isRingToOpenEnabled": false,
                     "isContinuousModeEnabled": false,
                     "isDoorbellEnabled": false,
+                    "suppressDoorbellOnRingToOpen": false,
+                    "suppressDoorbellInContinuousMode": false,
                     "isSingleAccessoryModeEnabled": false,
                     "unlatchFromLockedToUnlocked": false,
                     "unlatchFromUnlockedToUnlocked": false,
@@ -116,6 +118,10 @@ Start homebridge with the plugin installed, however, do not provide any devices 
 **isContinuousModeEnabled**: If set to true, a switch is exposed for the continuous mode. (only for Opener)
 
 **isDoorbellEnabled**: If set to true, you get doorbell notifications via the Apple Home app. (only for Opener)
+
+**suppressDoorbellOnRingToOpen**: If set to true, you do not get doorbell notifications via the Apple Home app when ring-to-open is enabled. (only for Opener)
+
+**suppressDoorbellInContinuousMode**: If set to true, you do not get doorbell notifications via the Apple Home app when continuous mode is enabled. (only for Opener)
 
 **isSingleAccessoryModeEnabled**: By default, the ring-to-open and continuous mode switches are placed in a separate accessory (Opener only, works best in the Apple Home app), and the lock and door sensor are also played in a separate accessory (SmartLock only). If this value is set to true, those services are all exposed in a single accessory.
 


### PR DESCRIPTION
Hi @lukasroegner,

I have been using the doorbell feature of the Opener for a while now. What has bothered me from the beginning is the fact that when the doorbell ring suppression is turned on, my HomePod still rings and a push notification is sent out. This is especially annoying when I want to ring myself in and someone is sleeping at home 😐

Actually, the Opener should not send a ring notification as a callback at all when doorbell ring suppression is active. Maybe it only does not work for the case where RTO is automatically reset at the first ring.

I have made a few adjustments in this regard that allows to enable doorbell suppression via configuration.

Thanks a lot,
Felix

![ring-suppression](https://user-images.githubusercontent.com/115331/125162270-2a36c880-e187-11eb-80d6-3d9a0a05da8e.png)
![rto-reset](https://user-images.githubusercontent.com/115331/125162273-2b67f580-e187-11eb-9e64-7cf9398b16dc.png)
